### PR TITLE
fix generators numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,11 @@ problem, solution = mathgen.genById(0)
 | 57 | Trigonometric Values | What is cos(60)? | 1/2 | basicTrigonometry |
 | 58 | Sum of Angles of Polygon | Sum of angles of polygon with 5 sides =  | 540 | sumOfAnglesOfPolygon |
 | 59 | Mean,Standard Deviation,Variance | Find the mean,standard deviation and variance for the data[38, 29, 43, 25, 7, 10, 13, 14, 43, 44, 30, 42, 48, 48, 42] | The Mean is 31.733333333333334 , Standard Deviation is 199.26222222222222, Variance is 14.116027140177303 | dataSummary |
-| 59 | Surface Area of Sphere | Surface area of Sphere with radius = 13m is | 2123.7166338267 m^2 | surfaceAreaSphereGen |
-| 60 | Volume of Sphere | Volume of sphere with radius 84 m =  | 2482712.7095377133 m^3 | volumeSphere |
+| 60 | Surface Area of Sphere | Surface area of Sphere with radius = 12m is | 1809.5573684677208 m^2 | surfaceAreaSphereGen |
+| 61 | Volume of Sphere | Volume of sphere with radius 14 m =  | 11494.040321933857 m^3 | volumeSphere |
+| 62 | nth Fibonacci number | What is the 17th Fibonacci number? | 1597 | nthFibonacciNumberGen |
+| 64 | Binary to Hexidecimal | 00 | 0x0 | binaryToHex |
+| 65 | Multiplication of 2 complex numbers | (13-8j) * (-7-5j) =  | (-131-9j) | complexNumMultiply |
+| 66 | Geometric Progression | For the given GP [12, 48, 192, 768, 3072, 12288] ,Find the value of a,common ratio,9th term value, sum upto 11th term | The value of a is 12, common ratio is 4 , 9th term is 786432 , sum upto 11th term is 16777212.0 | geometricprogression |
+| 67 | Geometric Mean of N Numbers | Geometric mean of 2 numbers 42 and 40 =  | (42*40)^(1/2) = 40.98780306383839 | geometricMean |
+| 68 | Harmonic Mean of N Numbers | Harmonic mean of 4 numbers 53 , 62 , 72 , 35 =  |  4/((1/53) + (1/62) + (1/72) + (1/35)) = 51.64137311701554 | harmonicMean |

--- a/mathgenerator/mathgen.py
+++ b/mathgenerator/mathgen.py
@@ -146,13 +146,13 @@ sumOfAnglesOfPolygon = Generator("Sum of Angles of Polygon", 58,
 dataSummary = Generator("Mean,Standard Deviation,Variance",
                         59, "a,b,c", "Mean:a+b+c/3,Std,Var", dataSummaryFunc)
 surfaceAreaSphereGen = Generator(
-    "Surface Area of Sphere", 59, "Surface area of sphere with radius = a units is", "d units^2", surfaceAreaSphere)
-volumeSphere = Generator("Volume of Sphere", 60,
+    "Surface Area of Sphere", 60, "Surface area of sphere with radius = a units is", "d units^2", surfaceAreaSphere)
+volumeSphere = Generator("Volume of Sphere", 61,
                          "Volume of sphere with radius r m = ", "(4*pi/3)*r*r*r", volumeSphereFunc)
-nthFibonacciNumberGen = Generator("nth Fibonacci number", 61, "What is the nth Fibonacci number", "Fn", nthFibonacciNumberFunc)
-profitLossPercent = Generator("Profit or Loss Percent", 62, "Profit/ Loss percent when CP = cp and SP = sp is: ", "percent", profitLossPercentFunc)
-binaryToHex = Generator("Binary to Hexidecimal", 63, "Hexidecimal of a=", "b", binaryToHexFunc)
-complexNumMultiply = Generator("Multiplication of 2 complex numbers", 64, "(x + j) (y + j) = ", "xy + xj + yj -1", multiplyComplexNumbersFunc)
-geometricprogression=Generator("Geometric Progression", 65, "Initial value,Common Ratio,nth Term,Sum till nth term =", "a,r,ar^n-1,sum(ar^n-1", geomProgrFunc)
-geometricMean=Generator("Geometric Mean of N Numbers",66,"Geometric mean of n numbers A1 , A2 , ... , An = ","(A1*A2*...An)^(1/n) = ans",geometricMeanFunc)
-harmonicMean=Generator("Harmonic Mean of N Numbers",67,"Harmonic mean of n numbers A1 , A2 , ... , An = "," n/((1/A1) + (1/A2) + ... + (1/An)) = ans",harmonicMeanFunc)
+nthFibonacciNumberGen = Generator("nth Fibonacci number", 62, "What is the nth Fibonacci number", "Fn", nthFibonacciNumberFunc)
+profitLossPercent = Generator("Profit or Loss Percent", 63, "Profit/ Loss percent when CP = cp and SP = sp is: ", "percent", profitLossPercentFunc)
+binaryToHex = Generator("Binary to Hexidecimal", 64, "Hexidecimal of a=", "b", binaryToHexFunc)
+complexNumMultiply = Generator("Multiplication of 2 complex numbers", 65, "(x + j) (y + j) = ", "xy + xj + yj -1", multiplyComplexNumbersFunc)
+geometricprogression=Generator("Geometric Progression", 66, "Initial value,Common Ratio,nth Term,Sum till nth term =", "a,r,ar^n-1,sum(ar^n-1", geomProgrFunc)
+geometricMean=Generator("Geometric Mean of N Numbers",67,"Geometric mean of n numbers A1 , A2 , ... , An = ","(A1*A2*...An)^(1/n) = ans",geometricMeanFunc)
+harmonicMean=Generator("Harmonic Mean of N Numbers",68,"Harmonic mean of n numbers A1 , A2 , ... , An = "," n/((1/A1) + (1/A2) + ... + (1/An)) = ans",harmonicMeanFunc)


### PR DESCRIPTION
Changes the numbering of the generators in mathgen.py, and the README accordingly, in order to remove the duplicate ID 59.
Fixes #232 .