### PR TITLE
Add PYTHON variable to Makefile

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,31 +4,29 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
 
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-    - name: Install Dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        pip install -r dev-requirements.txt
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: make deps
 
-    - name: Linter
-      run: make lint
+      - name: Linter
+        run: make lint
 
-    - name: Test
-      run: make test
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 IGNORE_ERRORS = E501,F401,F403,F405
 PKG = mathgenerator
+PYTHON ?= python3
+
+deps:
+	$(PYTHON) -m pip install --user -r dev-requirements.txt
 
 format:
-	python -m autopep8 --ignore=$(IGNORE_ERRORS) -ir $(PKG)/*
+	$(PYTHON) -m autopep8 --ignore=$(IGNORE_ERRORS) -ir $(PKG)/*
 
 lint:
-	python -m flake8 --ignore=$(IGNORE_ERRORS) $(PKG)
+	$(PYTHON) -m flake8 --ignore=$(IGNORE_ERRORS) $(PKG)
 
 test:
-	python -m pytest --verbose -s tests
+	$(PYTHON) -m pytest --verbose -s tests


### PR DESCRIPTION
Fix #291 to support machines with `python3`

You can provide different python executables with
```bash
PYTHON=python2.7 make test
# or
make test PYTHON=python3.8
```