### PR TITLE
Fixed faulty multiplication test #351

### DIFF
--- a/tests/test_mathgen.py
+++ b/tests/test_mathgen.py
@@ -17,13 +17,12 @@ def test_subtraction(maxMinuend, maxDiff):
     problem, solution = subtraction.func(maxMinuend, maxDiff)
     assert eval(problem[:-1]) == int(solution)
 
-"""
-@given(maxRes=st.integers(min_value=1), maxMulti=st.integers(min_value=1))
-def test_multiplication(maxRes, maxMulti):
-    assume(maxRes > maxMulti)
-    problem, solution = multiplication.func(maxRes, maxMulti)
+
+@given(maxMulti=st.integers(min_value=1))
+def test_multiplication(maxMulti):
+    problem, solution = multiplication.func(maxMulti)
     assert eval(problem[:-1]) == int(solution)
-"""
+
 
 @given(maxA=st.integers(min_value=1), maxB=st.integers(min_value=1))
 def test_division(maxA, maxB):


### PR DESCRIPTION
Fixed the multiplication test issue. 
The error was in passing a maxRes parameter as an argument to the multiplication.func() call since multiplication.func only takes one argument i.e. maxMulti. Also within the hypothesis given() decorator function maxRes wasn't required as well so removed that too. Lastly we did not need to assume anything while testing the multiplication function as we do need to check if any one operand is greater than the other one while doing basic multiplication. 