### PR TITLE
Updated equation_of_line_from_two_points.py

### DIFF
--- a/mathgenerator/funcs/geometry/equation_of_line_from_two_points.py
+++ b/mathgenerator/funcs/geometry/equation_of_line_from_two_points.py
@@ -2,11 +2,11 @@ from .__init__ import *
 
 
 def gen_func(maxCoordinate=20, minCoordinate=-20, format='string'):
-    def greatest_common_divisor(num1,num2):
-        if num2==0:
+    def greatest_common_divisor(num1, num2):
+        if num2 == 0:
             return num1
         else:
-            return greatest_common_divisor(num2 , num1%num2)
+            return greatest_common_divisor(num2, num1 % num2)
 
     x1 = random.randint(minCoordinate, maxCoordinate)
     x2 = random.randint(minCoordinate, maxCoordinate)
@@ -14,27 +14,27 @@ def gen_func(maxCoordinate=20, minCoordinate=-20, format='string'):
     y1 = random.randint(minCoordinate, maxCoordinate)
     y2 = random.randint(minCoordinate, maxCoordinate)
 
-    coeff_y = (x2-x1)
-    coeff_x = (y2-y1)
-    constant = y2*coeff_y - x2*coeff_x
+    coeff_y = (x2 - x1)
+    coeff_x = (y2 - y1)
+    constant = y2 * coeff_y - x2 * coeff_x
 
     gcd = greatest_common_divisor(abs(coeff_x), abs(coeff_y))
 
-    if gcd !=1:
+    if gcd != 1:
         if coeff_y > 0: coeff_y //= gcd
         if coeff_x > 0: coeff_x //= gcd
         if constant > 0: constant //= gcd
-        if coeff_y < 0: coeff_y = -(-coeff_y//gcd)
-        if coeff_x < 0: coeff_x = -(-coeff_x//gcd)
-        if constant < 0: constant = -(-constant//gcd)
-    if coeff_y < 0 :
+        if coeff_y < 0: coeff_y = -(-coeff_y // gcd)
+        if coeff_x < 0: coeff_x = -(-coeff_x // gcd)
+        if constant < 0: constant = -(-constant // gcd)
+    if coeff_y < 0:
         coeff_y = -(coeff_y)
         coeff_x = -(coeff_x)
         constant = -(constant)
-    if coeff_x in [1,-1]:
+    if coeff_x in [1, -1]:
         if coeff_x == 1: coeff_x = ''
         else: coeff_x = '-'
-    if coeff_y in [1,-1]:
+    if coeff_y in [1, -1]:
         if coeff_y == 1: coeff_y = ''
         else: coeff_y = '-'
     if format == 'string':

--- a/mathgenerator/funcs/geometry/equation_of_line_from_two_points.py
+++ b/mathgenerator/funcs/geometry/equation_of_line_from_two_points.py
@@ -1,0 +1,60 @@
+from .__init__ import *
+
+
+def gen_func(maxCoordinate=20, minCoordinate=-20, format='string'):
+    def greatest_common_divisor(num1,num2):
+        if num2==0:
+            return num1
+        else:
+            return greatest_common_divisor(num2 , num1%num2)
+
+    x1 = random.randint(minCoordinate, maxCoordinate)
+    x2 = random.randint(minCoordinate, maxCoordinate)
+
+    y1 = random.randint(minCoordinate, maxCoordinate)
+    y2 = random.randint(minCoordinate, maxCoordinate)
+
+    coeff_y = (x2-x1)
+    coeff_x = (y2-y1)
+    constant = y2*coeff_y - x2*coeff_x
+
+    gcd = greatest_common_divisor(abs(coeff_x), abs(coeff_y))
+
+    if gcd !=1:
+        if coeff_y > 0: coeff_y //= gcd
+        if coeff_x > 0: coeff_x //= gcd
+        if constant > 0: constant //= gcd
+        if coeff_y < 0: coeff_y = -(-coeff_y//gcd)
+        if coeff_x < 0: coeff_x = -(-coeff_x//gcd)
+        if constant < 0: constant = -(-constant//gcd)
+    if coeff_y < 0 :
+        coeff_y = -(coeff_y)
+        coeff_x = -(coeff_x)
+        constant = -(constant)
+    if coeff_x in [1,-1]:
+        if coeff_x == 1: coeff_x = ''
+        else: coeff_x = '-'
+    if coeff_y in [1,-1]:
+        if coeff_y == 1: coeff_y = ''
+        else: coeff_y = '-'
+    if format == 'string':
+        problem = f"What is the equation of the line between points ({x1},{y1}) and ({x2},{y2}) in slope-intercept form?"
+        if coeff_x == 0:
+            solution = str(coeff_y) + "y = " + str(constant)
+        elif coeff_y == 0:
+            solution = str(coeff_x) + "x = " + str(-constant)
+        else:
+            if constant > 0:
+                solution = str(coeff_y) + "y = " + str(coeff_x) + "x + " + str(constant)
+            else:
+                solution = str(coeff_y) + "y = " + str(coeff_x) + "x " + str(constant)
+        return problem, solution
+    elif format == 'latex':
+        return 'Latex unavailable'
+    else:
+        return x1, x2, y1, y2, coeff_x, coeff_y, constant
+
+
+equation_of_line_from_two_points = Generator(
+            "Equation of line from two points", 114, gen_func,
+            ["maxCoordinate=20", "minCoordinate=-20"])


### PR DESCRIPTION
The generator got deleted in a previous commit. I added it back in and updated it for the following.
Added cases to generate proper equations when:
1) The coefficient of x equals one. Will print "x" instead of "1x"
2) The coefficient of y equals one. Will print "y" instead of "1y"
3) The coefficient of y or x equals zero. Will print equation appropriately instead of "0y" or "0x"
Please let me know if anything needs to be modified.