### PR TITLE
webpage redesign

### DIFF
--- a/data.js
+++ b/data.js
@@ -1815,7 +1815,7 @@ const data = [
             "maxSide=20",
             "unit='m'"
         ],
-        "name": "Volum of Cube",
+        "name": "Volume of Cube",
         "samples": [
             {
                 "problem": "Volume of cube with side = 7m is",

--- a/index.html
+++ b/index.html
@@ -14,39 +14,47 @@
 	<p>mathgenerator is a python package that enables users to easily generate a variety of math problems, with customizable settings.</p>
 	<hr></hr>
 	<h2>Demo</h2>
-	<div id="generatorBox" class="customBox">
-		<p id="agTitle" >Addition</p>
-		<div class="agItem">
-			<p class="agLabel">function name:</p>
-			<p id="agFunctionName">addition</p>
-		</div>
-		<div class="agItem">
-			<p class="agLabel">subject:</p>
-			<p id="agSubject">basic_math</p>
-		</div>
-		<div class="agItem">
-			<p class="agLabel">kwargs:</p>
-			<p id="agKwargs">maxSum=99, maxAddend=50</p>
-		</div>
-		<div class="agItem">
-			<p class="agLabel">id:</p>
-			<p id="agId">0</p>
-		</div class="agItem">
-		<div id="agSample">
-			<div>
-				<p class="agLabel">Problem:</p>
-				<p id="agProblem">2+2=</p>
+	
+	<div id="mainContent">
+		<div class="col">
+			<div id="generatorBox" class="customBox">
+				<p id="agTitle" >Addition</p>
+				<div class="agItem">
+					<p class="agLabel">function name:</p>
+					<p id="agFunctionName">addition</p>
+				</div>
+				<div class="agItem">
+					<p class="agLabel">subject:</p>
+					<p id="agSubject">basic_math</p>
+				</div>
+				<div class="agItem">
+					<p class="agLabel">kwargs:</p>
+					<p id="agKwargs">maxSum=99, maxAddend=50</p>
+				</div>
+				<div class="agItem">
+					<p class="agLabel">id:</p>
+					<p id="agId">0</p>
+				</div class="agItem">
+				<div id="agSample">
+					<div>
+						<p class="agLabel">Problem:</p>
+						<p id="agProblem">2+2=</p>
+					</div>
+					<div>
+						<p class="agLabel">Solution:</p>
+						<p id="agSolution">4</p>
+					</div>
+				</div>
+				<button id="newProblemButton" onClick="generateSample()">Generate</button>
 			</div>
-			<div>
-				<p class="agLabel">Solution:</p>
-				<p id="agSolution">4</p>
+		</div>
+
+		<div class="col">
+			<div id="generatorList" class="customBox">
+				<h3>Available Generators</h3>
+				<p>Click a generator to show a sample problem and more info</p>
 			</div>
 		</div>
-		<button id="newProblemButton" onClick="generateSample()">Generate</button>
-	</div>
-  	<div id="generatorList" class="customBox">
-		<h3>Available Generators</h3>
-		<p>Click a generator to show a sample problem and more info</p>
 	</div>
 	<script type="text/javascript" src="main.js"></script>
 </body>

--- a/main.css
+++ b/main.css
@@ -6,7 +6,6 @@ html, body {
   background-color: #2C2C2C;
   color: #E3E3E3;
   width: 95%;
-  max-width: 600px;
   margin: auto;
 }
 a {
@@ -24,11 +23,21 @@ h2 {
   margin: 0;
   margin-bottom: 15px;
 }
+#mainContent {
+  display: flex;
+  flex-wrap: wrap;
+}
+.col {
+  width: 50%;
+}
+.col > div{
+  margin: 10px;
+}
 .customBox {
 background-color: #38393A;
 padding: 10px;
-margin: auto;
-    border-radius: 10px;
+
+border-radius: 10px;
 }
 #pipBox {
   width: 300px;
@@ -36,12 +45,10 @@ margin: auto;
   border-radius: 5px;
 }
 #generatorBox {
+  position: sticky;
+  top: 20px;
   margin-bottom: 10px;
-  width: 90%;
-  max-width: 500px;
   padding: 30px;
-  margin: auto;
-  margin-bottom: 10px;
 }
 #generatorBox p {
   text-align: left;
@@ -54,9 +61,6 @@ margin: auto;
 display: flex;
 }
 #generatorList {
-  width: 90%;
-  max-width: 500px;
-  margin: auto;
   padding: 30px;
 }
 #generatorList * {
@@ -103,8 +107,19 @@ button {
   font-size: 14px;
   margin: auto;
   margin-top: 20px;
+  cursor: pointer;
 }
 button:active {
   color: #A89C9C;
   background-color: #8A2323;
+}
+
+@media only screen and (max-width: 790px) {
+  #mainContent {
+    display: grid;
+    justify-items: center;
+  }
+  .col {
+    width: 95%;
+  }
 }

--- a/main.js
+++ b/main.js
@@ -1,14 +1,14 @@
 for (let i=0; i<data.length-1; i++) {
 	var div = document.createElement("DIV");
         div.className = "generatorListItem"
-        div.innerHTML = "<p class='genListItem' onClick='setAg(" + data[i].id + ")'>" + data[i].name + "</p>";
+        div.innerHTML = "<p class='genListItem'>" + data[i].name + "</p>";
         document.getElementById("generatorList").appendChild(div);
 }
 function setAg(id) {
 	let gen = data[id];
         document.getElementById("agTitle").innerHTML = gen.name;
         document.getElementById("agFunctionName").innerHTML = gen.function_name;
-        document.getElementById("agKwargs").innerHTML = gen.kwargs;
+        document.getElementById("agKwargs").innerHTML = gen.kwargs.join(", ");
         document.getElementById("agId").innerHTML = gen.id;
         generateSample(id);
 }
@@ -18,4 +18,15 @@ function generateSample(agId=-1) {
         let set = data[agId].samples[sampleId];
         document.getElementById("agProblem").innerHTML = set.problem;
         document.getElementById("agSolution").innerHTML = set.solution;
+}
+
+
+let elements = document.getElementsByClassName("genListItem");
+for(let i = 0; i < elements.length; i++) {
+        elements[i].onclick = function () {
+                setAg(data[i].id)
+                if (window.innerWidth < 790) {
+                        window.scrollTo(0, 0)
+                }
+        }
 }


### PR DESCRIPTION
### Website Redesign
- Implemented desktop first page design. 
- Added a container with 2 columns in the html mark up.
- Container is set to a flexbox, thereby allowing for columns for a desktop screen
- Made the generator stick to the top of the screen.
- Added media query in to optimise for mobile screen once screen width is below 790px.
- Removed onclick properties from `genListItem` as this is not a good practice.
    - Instead, I set up an onclick listener in `main.js` to changer the generator,
    - In the same listener, I made the links scroll if top if screen width is below 790px.
   
### Miscellaneous
- Fixed typo `Volum` in `data.js`.
- Cursor enters select mode on generate button hover.
- Added spacing between each `kwargs`

### Observations
- Fixes #357, #368.
- JS is not correctly linted. I've kept my commits to the original linting style but I recommend to use a linter/formatter of some sort to reformat JS files.