### PR TITLE
Fix issue of path separators and UnicodeDecodeError on adoptGenerator.py

### DIFF
--- a/mathgenerator/__init__.py
+++ b/mathgenerator/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import traceback
 
@@ -8,7 +9,7 @@ import scipy
 
 genList = []
 
-
+SEP = os.sep
 class Generator:
     def __init__(self, title, id, func, kwargs):
         self.title = title
@@ -18,10 +19,10 @@ class Generator:
 
         (filename, line_number, function_name,
          text) = traceback.extract_stack()[-2]
-        funcname = filename[filename.rfind('/'):].strip()
+        funcname = filename[filename.rfind(SEP):].strip()
         funcname = funcname[1:-3]
-        subjectname = filename[:filename.rfind('/')].strip()
-        subjectname = subjectname[subjectname.rfind('/'):].strip()
+        subjectname = filename[:filename.rfind(SEP)].strip()
+        subjectname = subjectname[subjectname.rfind(SEP):].strip()
         subjectname = subjectname[1:]
         genList.append([id, title, self, funcname, subjectname, kwargs])
 

--- a/scripts/makeReadme.py
+++ b/scripts/makeReadme.py
@@ -144,7 +144,7 @@ def main():
         for write_line in write_list:
             lines.append(write_line)
 
-    with open('../README.md', "w") as g:
+    with open('../README.md', "w", encoding = 'utf-8') as g:
         g.writelines(lines)
 
     print("New README.md table generated")


### PR DESCRIPTION
This PR attempts to fix problems with `adoptGenerator.py`, specifically, when running `main()` imported from `makeReadme`, as follows:

1. I've explained the path separators issue on #378. Basically, there's an unintended result when running `adoptGenerator.py` on my device and I highly suspect it's because Windows has backslash `\` as path separator. I've replaced the hardcoded separator `/` with `os.sep` to make it work with as minimal change as possible.

2. There are Unicode symbols present in `mathgenerator/funcs/geometry/basic_trigonometry.py`. I've changed how `makeReadme` open file by adding the argument `encoding = "utf-8"`. Without this argument, running `adoptGenerator.py` on my device is pointless as it raises UnicodeDecodeError every time. I'm not 100% sure if adding that argument will affect devices with different configurations/specs.

I don't have an access to other device apart from my own, so unfortunately I can't test to see if my proposed change can have side-effects on other OSes.