### PR TITLE
Versatilize input order for distance_two_points

### DIFF
--- a/mathgenerator/algebra.py
+++ b/mathgenerator/algebra.py
@@ -158,6 +158,8 @@ def distance_two_points(max_val_xy=20, min_val_xy=-20):
     | --- | --- |
     | Find the distance between $(-19, -6)$ and $(15, -16)$ | $\sqrt{1256}$ |
     """
+    if max_val_xy < min_val_xy: max_val_xy, min_val_xy = min_val_xy, max_val_xy
+
     point1X = random.randint(min_val_xy, max_val_xy + 1)
     point1Y = random.randint(min_val_xy, max_val_xy + 1)
     point2X = random.randint(min_val_xy, max_val_xy + 1)


### PR DESCRIPTION
Algebra.distance_two_points takes 2 inputs: the max value used for the two points and the min value used for the two points. This change eliminates the need for these values to be in the specific (max, min) order.