### PR TITLE
fix(#445-power_rule_differentiation should hide unnecessary powers):

### DIFF
--- a/mathgenerator/calculus.py
+++ b/mathgenerator/calculus.py
@@ -44,7 +44,11 @@ def power_rule_differentiation(max_coef=10, max_exp=10, max_terms=5):
 
         problem += f'{coefficient}x^{{{exponent}}}'
         solution += f'{coefficient * exponent}x^{{{exponent - 1}}}'
-
+    
+    problem = problem.replace('x^{1}', 'x')
+    problem = problem.replace('x^{0}', '')
+    solution = solution.replace('x^{1}', 'x')
+    solution = solution.replace('x^{0}', '')
     return problem + '$', solution + '$'
 
 


### PR DESCRIPTION
fixed by string.replace()
Code is readable, but O(N*M) might be overkill for what is essentially a string parsing problem. Im assuming though that performance is not main priority